### PR TITLE
Add Grafana to Kubernetes cluster

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -20,6 +20,9 @@ their current status.
   instances.
 - `prometheus (deployed, guiding-principles-not-applied)`: We deploy
   [Prometheus](https://prometheus.io) for monitoring and alerting.
+- `grafana (deployed, guiding-principles-not-applied)`: We deploy
+  [Grafana](https://grafana.org) for dashboards.
+
 
 ## Guiding principles
 
@@ -111,6 +114,7 @@ deployed.
 - Each application should use a `NetworkPolicy` to limit access to only intended
   other pods. By default, only pods in the global namespace (i.e. prometheus) should be
   allowed to access. At most, only pods within the namespace and global pods should be allowed to access.
+- @TODO(mattjmcnaughton) Add something around PodSecurity policy.
 - @TODO(mattjmcnaughton) Container image security scanning should be a component
   of CI. I'm not exactly sure what existing technologies there are which support
   this.

--- a/applications/grafana/README.md
+++ b/applications/grafana/README.md
@@ -1,0 +1,15 @@
+# grafana
+
+This project contains the code necessary to run the
+[Grafana](https://grafana.org) application we use to create useful dashboards of
+our monitoring data.
+
+## Derivations from Guiding principles
+
+@TODO(mattjmcnaughton) We have not yet implemented the guiding principles for
+this application, so we can't discuss how it violates them.
+
+One important note is that we do not currently expose our Grafana cluster to
+the public internet, because we do not have `https` or any form of meaningful auth. Until
+we are able to implement those, we'll use port-forwarding: `kubectl port-forward
+svc/grafana 3000:3000`.

--- a/applications/grafana/templates/configmap-config.yaml
+++ b/applications/grafana/templates/configmap-config.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-config
+data:
+  grafana.ini: |-
+    instance_name = grafana
+
+    [log]
+    mode = console
+
+  datasource.yaml: |-
+    apiVersion: 1
+
+    deleteDatasources:
+      - name: Graphite
+        orgId: 1
+
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        editable: false
+
+  dashboards.yaml: |-
+    apiVersion: 1
+
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      updateIntervalSeconds: 10
+      options:
+        path: /var/lib/grafana/dashboards

--- a/applications/grafana/templates/configmap-dashboards.yaml
+++ b/applications/grafana/templates/configmap-dashboards.yaml
@@ -1,0 +1,161 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+data:
+  prometheus-gitops-demo.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "A demo of using Gitops to create dashboard reading from Prometheus.",
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 1,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Overview of response counts.",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(caddy_http_response_status_count_total{status=\"200\"})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "A"
+            },
+            {
+              "expr": "",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP Response Count Status",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": [
+        "prometheus"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "prometheus-gitops-demo",
+      "uid": "7MRIBiaik",
+      "version": 2
+    }

--- a/applications/grafana/templates/deployment.yaml
+++ b/applications/grafana/templates/deployment.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      serviceAccountName: grafana
+      containers:
+      - name: grafana
+        image: docker.io/grafana/grafana:5.3.2
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        env:
+          # @TODO(mattjmcnaughton) Long term, this password should certainly not
+          # be plain text nor `password`. For now, it doesn't matter as the
+          # service is not accessible from the public internet.
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          value: password
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/grafana/grafana.ini
+          subPath: grafana.ini
+        - name: config-volume
+          mountPath: /etc/grafana/provisioning/datasources/prometheus.yaml
+          subPath: datasource.yaml
+        - name: config-volume
+          mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
+          subPath: dashboards.yaml
+        - name: dashboards-volume
+          mountPath: /var/lib/grafana/dashboards
+      volumes:
+        - name: config-volume
+          configMap:
+            name: grafana-config
+        - name: dashboards-volume
+          configMap:
+            name: grafana-dashboards
+

--- a/applications/grafana/templates/role.yaml
+++ b/applications/grafana/templates/role.yaml
@@ -1,0 +1,6 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: grafana
+rules: []

--- a/applications/grafana/templates/rolebinding.yaml
+++ b/applications/grafana/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: grafana
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: grafana
+subjects:
+- kind: ServiceAccount
+  name: grafana
+

--- a/applications/grafana/templates/service-account.yaml
+++ b/applications/grafana/templates/service-account.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana

--- a/applications/grafana/templates/service.yaml
+++ b/applications/grafana/templates/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+spec:
+  type: ClusterIP
+  selector:
+    app: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP


### PR DESCRIPTION
Deploy Grafana to our Kubernetes cluster. We write a very simple set of
manifests from scratch, which will go on to form a Helm chart.

For now, we hardcode a plain text password, but we'll want a better
strategy in place before deploying this to the public internet.

This commit only contains a WIP set of dashboards. We'll determine the
rest once we've deployed Grafana to production and can start playing
with production data.