### PR TITLE
Add Prometheus Rules and Alertmanager

### DIFF
--- a/applications/alertmanager/README.md
+++ b/applications/alertmanager/README.md
@@ -1,0 +1,34 @@
+# alertmanager
+
+This project contains the code necessary to run the
+[Alertmanager](https://prometheus.io/docs/alerting/alertmanager/) application
+which is responsible for handling alerts sent by the client (i.e. Prometheus).
+
+## Derivations from Guiding principles
+
+@TODO(mattjmcnaughton) We have not yet implemented the guiding principles for
+this application, so we can't discuss how it violates them.
+
+One important note is that we do not currently expose our Alertmanager to
+the public internet, because we do not have `https` or any form of auth. Until
+we are able to implement those, we'll use port-forwarding: `kubectl port-forward
+svc/prometheus 9093:9093`.
+
+Additionally, one of our manifests is for a `Secret` resource. We want to store
+the secret in a file (for now), so that `kubectl apply -f templates/` still
+creates all necessary resources. However, we do not want to store the actual
+`Secret` file in source control. As such, we make use of a `.sample` file which
+we template via the `envsubst` command. Instructions for doing so can be found
+below. We should run this every time we update
+`alertmanager-config.yaml.sample`.
+
+```bash
+export OPSGENIE_API_KEY=...
+export ALERTMANAGER_YAML_BASE64=$(cat alertmanager-config.yaml.sample | envsubst | base64 | tr -d '\n')
+cat secret.yaml.sample | envsubst > secret.yaml
+```
+
+## Notes
+
+We based this code on the manifests in [CoreOS'
+kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus/manifests).

--- a/applications/alertmanager/templates/.gitignore
+++ b/applications/alertmanager/templates/.gitignore
@@ -1,0 +1,1 @@
+secret.yaml

--- a/applications/alertmanager/templates/alertmanager-config.yaml.sample
+++ b/applications/alertmanager/templates/alertmanager-config.yaml.sample
@@ -1,0 +1,39 @@
+# Alertmanager's configuration file:
+# https://prometheus.io/docs/alerting/configuration/
+#
+# At a high level, we send critical alerts to Opsgenie and do nothing all others.
+
+global:
+  resolve_timeout: 5m
+  # IMPT: This file is checked into source control, so do not hard code any
+  # secrets. Rather, specify the environment variables and use `envsubst` as
+  # described in the README.
+  opsgenie_api_key: ${OPSGENIE_API_KEY}
+
+# Specify how we'll handle specific alerts based on their labels.
+route:
+  # Alerts should be independent across services.
+  group_by: ['alertname', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  # The default destination for unmatched alerts its `null` (i.e. do nothing).
+  receiver: 'null'
+
+  # Specify the more specific routing subtree.
+  routes:
+  # For alerts with the `severity=critical` label, send them to Opsgenie.
+  - match_re:
+      severity: critical
+    receiver: opsgenie
+
+# Specify the different options for handling alerts.
+receivers:
+# The `null` receiver does nothing with an alert.
+- name: 'null'
+# The `opsgenie` receiver sends the alert to Opsgenie. Currently this defaults
+# to the `personal-k8s` "on-call" rotation. We can think about having a per
+# application "on-call" rotations, but for now that seems too heavyweight.
+- name: 'opsgenie'
+  opsgenie_configs:
+  - priority: P1

--- a/applications/alertmanager/templates/alertmanager.yaml
+++ b/applications/alertmanager/templates/alertmanager.yaml
@@ -1,0 +1,13 @@
+---
+# This manifest declares that we want an Alertmanager cluster deployed via the
+# Prometheus operator. Note, in order to use the `Alertmanager` CRD, we must
+# first deploy CoreOS's Prometheus Operator.
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: alertmanager
+spec:
+  # Our Alertmanager should have at least two replicas so that its high
+  # availability.
+  replicas: 2
+  serviceAccountName: alertmanager

--- a/applications/alertmanager/templates/role.yaml
+++ b/applications/alertmanager/templates/role.yaml
@@ -1,0 +1,10 @@
+---
+# This manifest declares the Role under which our Alertmanager pods will run.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: alertmanager
+# @TODO(mattjmcnaughton) Long term, should we create (or utilize if it already
+# exists) a single role specifying the ServiceAccount should not interact with
+# the Kubernetes API.
+rules: []

--- a/applications/alertmanager/templates/rolebinding.yaml
+++ b/applications/alertmanager/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+# This manifest declares a RoleBinding binding the alertmanager role to the
+# alertmanager ServiceAccount.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: alertmanager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alertmanager
+subjects:
+- kind: ServiceAccount
+  name: alertmanager
+

--- a/applications/alertmanager/templates/secret.yaml.sample
+++ b/applications/alertmanager/templates/secret.yaml.sample
@@ -1,0 +1,19 @@
+---
+# This manifest is responsible for creating the Secret the CoreOS Prometheus
+# Operator requires to configure Alertmanager instances:
+# https://coreos.com/operators/prometheus/docs/latest/user-guides/alerting.html.
+# It must be a secret because `alertmanager.yaml` could contain sensitive
+# tokens. We check the `.sample` file into source control, so do not write any
+# secrets there; rather, use `envsubst` to generate the actual Secret manifest
+# as described in the README.md. The Secret manifest file should not be written
+# to source control.
+apiVersion: v1
+kind: Secret
+metadata:
+  # The Prometheus Operator requires we use the format `alertmanager-NAME`, and
+  # for us, our Alertmanager is named `alertmanager`.
+  name: alertmanager-alertmanager
+data:
+  # The base64 encoded configuration file for our Alertmanager (without any line
+  # breaks).
+  alertmanager.yaml: ${ALERTMANAGER_YAML_BASE64}

--- a/applications/alertmanager/templates/service-account.yaml
+++ b/applications/alertmanager/templates/service-account.yaml
@@ -1,0 +1,7 @@
+---
+# This manifest is responsible for creating the ServiceAccount with which we'll
+# run our Alertmanager pods.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alertmanager

--- a/applications/alertmanager/templates/service.yaml
+++ b/applications/alertmanager/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+# This manifest declares the Service which allows us to access Alertmanager
+# (either internally or externally).
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+spec:
+  # @TODO(mattjmcnaughton) We temporarily use a ClusterIP, because we don't want this externally accessible
+  # from the internet until we have some form of authentication. We can't have
+  # some form of meaningful authentication until we have https. We can access it
+  # from our local machine using port forwarding. Once we have `https` and
+  # authentication, we can make it a `LoadBalancer`.
+  type: ClusterIP
+  ports:
+  - name: web
+    # By default, Alertmanager listens on port 9093.
+    port: 9093
+    protocol: TCP
+    targetPort: web
+  selector:
+    alertmanager: alertmanager

--- a/applications/prometheus-operator/README.md
+++ b/applications/prometheus-operator/README.md
@@ -17,3 +17,10 @@ We do not have any automated method of staying in sync with upstream, although
 we should periodically ensure that we are staying up to date with the latest
 versions of the CoreOS [Prometheus
 Operator](https://github.com/coreos/prometheus-operator).
+
+We know that version 0.17 has known bugs with respect to attaching
+PrometheusRules to our Prometheus cluster. We know those bugs are fixed in 0.24.
+There may be working versions in between, but for now we use 0.24.
+
+Additionally, I've had to add permissions to the `prometheus-operator` cluster
+role in order for it to function correctly.

--- a/applications/prometheus-operator/templates/cluster-role.yaml
+++ b/applications/prometheus-operator/templates/cluster-role.yaml
@@ -1,4 +1,6 @@
 ---
+# Note: I've had to add rules beyond what I initially found on Github when
+# upgrading from 0.17 to 0.24.
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -21,6 +23,7 @@ rules:
   resources:
   - alertmanagers
   - prometheuses
+  - prometheusrules
   - prometheuses/finalizers
   - servicemonitors
   verbs:
@@ -51,4 +54,4 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
-  verbs: ["list"]
+  verbs: ["list", "watch"]

--- a/applications/prometheus-operator/templates/deployment.yaml
+++ b/applications/prometheus-operator/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        image: quay.io/coreos/prometheus-operator:v0.17.0
+        # We know that certain PrometheusRule operations fail with 0.17 and
+        # succeed with 0.24, so use at least 0.24.
+        image: quay.io/coreos/prometheus-operator:v0.24.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/applications/prometheus/templates/prometheus.yaml
+++ b/applications/prometheus/templates/prometheus.yaml
@@ -20,7 +20,22 @@ spec:
   # `serviceMonitorSelector`.
   serviceMonitorSelector:
     matchLabels:
-      app: blog
+      role: service-monitor
+  # PrometheusRules specify the rules under which Prometheus should fire alerts
+  # (which are handeled by AlertManager). We attach `PrometheusRules` to our
+  # `Prometheus` instance via the `ruleSelector`.
+  ruleSelector:
+    matchLabels:
+      role: alert-rules
+  # Configure our Prometheus instance to send alerts to the `alertmanager`
+  # service.
+  alerting:
+    alertmanagers:
+    # @TODO(mattjmcnaughton) We'll want to update/template this namespace once
+    # we being making more advanced uses of namespaces.
+    - namespace: default
+      name: alertmanager
+      port: web
   resources:
     requests:
       memory: 400Mi

--- a/applications/prometheus/templates/rules-blog.yaml
+++ b/applications/prometheus/templates/rules-blog.yaml
@@ -1,0 +1,43 @@
+---
+# This manifest defines the PrometheusRules specific to our blog that we'll use
+# for monitoring/alerting for mattjmcnaughton.com. Each rule should be
+# self-explanatory, but we utilize the following conventions:
+#
+# - `severity=critical` indicates we should raise an alert via Opsgenie.
+# - 15m is the default `for`. We may refine this value over time.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: blog
+  labels:
+    app: blog
+    # Prometheus searches for any PrometheusRules with the `role=alert-rules`
+    # label.
+    role: alert-rules
+spec:
+  groups:
+  - name: blog.rules
+    rules:
+      - alert: BlogDown
+        annotations:
+          message: 'Unable to scrape metrics for blog. Is blog down?'
+        expr: 'absent(up{service="blog"}) == 1'
+        # Make `for` more aggressive, because there's less chance of this
+        # correcting itself.
+        for: 5m
+        labels:
+          severity: critical
+      - alert: SLOLatencyFailure
+        annotations:
+          message: 'Violating SLO that 99% latency is < 1s'
+        expr: 'histogram_quantile(0.99, sum(rate(caddy_http_request_duration_seconds_bucket{service="blog"}[1h])) by (le)) > 1'
+        for: 15m
+        labels:
+          severity: critical
+      - alert: SLOAvailabilityFailure
+        annotations:
+          message: 'Violating SLO that 99% of requests are successful'
+        expr: 'sum(rate(caddy_http_response_status_count_total{service="blog",status!~"5.."}[1h])) / sum(rate(caddy_http_response_status_count_total{service="blog"}[1h])) < .99'
+        for: 15m
+        labels:
+          severity: critical

--- a/applications/prometheus/templates/rules-general.yaml
+++ b/applications/prometheus/templates/rules-general.yaml
@@ -1,0 +1,23 @@
+---
+# This manifest defines the PrometheusRules generic to our cluster that we'll use
+# to ensure our alerting/monitoring pipelines work as expected.
+#
+# Currently, it is just the `DeadMansSwitch`.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: general
+  labels:
+    # Prometheus searches for any PrometheusRules with the `role=alert-rules`
+    # label.
+    role: alert-rules
+spec:
+  groups:
+  - name: general.rules
+    rules:
+      - alert: DeadMansSwitch
+        annotations:
+          message: This is a DeadMansSwitch meant to ensure that the entire alerting pipeline is functional.
+        expr: vector(1)
+        labels:
+          severity: none

--- a/applications/prometheus/templates/servicemonitor-blog.yaml
+++ b/applications/prometheus/templates/servicemonitor-blog.yaml
@@ -9,6 +9,9 @@ metadata:
   name: blog
   labels:
     app: blog
+    # Prometheus searches for any ServiceMonitor with the `role=service-monitor`
+    # label.
+    role: service-monitor
 spec:
   selector:
     # Scrape metrics for all pods with the `app=blog` label.


### PR DESCRIPTION
Follow the instructions in
https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md
to add Alertmanager. Additionally, add PrometheusRules for monitoring
our SLO.

For now, we use fairly primitive SLO monitoring (basically alert if our
SLO is violated for more than X minutes). Long term, it would be great
to monitor on error rate burn down, but I'm not sure I'm comfortable
enough with Prometheus yet.

Deploying Alertmanager requires us to specify a k8s Secret. For now,
we've defined the Secret as a file which we keep out of source control
by using a `.sample` file and `envsubst`. We should reconsider this once
we have a better secrets solution.

Alertmanager is configured to raise alerts via Opsgenie, on which I've
created a free account.

Note: We had to upgrade the version of the prometheus operator we use in
production.